### PR TITLE
Kj/initial implementation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,33 @@
+name: CI
+on:
+  - push
+  - pull_request
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.5'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+        env:
+          JULIA_NUM_THREADS: 4
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: lcov.info

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,4 @@
+name = "LabelledGraphs"
+uuid = "605abd48-4d17-4660-b914-d4df33194460"
+authors = ["Konrad Jałowiecki <dexter2206@gmail.com>"]
+version = "0.1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -5,3 +5,9 @@ version = "0.1.0"
 
 [deps]
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -2,3 +2,6 @@ name = "LabelledGraphs"
 uuid = "605abd48-4d17-4660-b914-d4df33194460"
 authors = ["Konrad Jałowiecki <dexter2206@gmail.com>"]
 version = "0.1.0"
+
+[deps]
+LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,55 @@
 # LabelledGraphs.jl
-Graphs with vertices labelled with arbitrary integers
+
+Graphs with vertices labelled with arbitrary objects.
+
+## Motivation
+
+Graphs from `LightGraphs` use vertices labelled with contiuous integer range starting from 1.
+This poses a problem if one wants to handle graphs whose vertices are labelled either by more general integer ranges or other objects (e.g. strings).
+`LabelledGraphs` extend `LightGraphs` by allowing more flexible labelling of verices.
+
+
+## Usage
+
+Labelled graph can be created by providing a sequence of labels, i.e.:
+
+```julia
+using LabelledGraphs
+
+lg = LabelledGraph(["a", "b", "c"]) # Undirected graph with vertices a, b, c
+ldg = LabelledDiGraph([4, 5, 10])   # Directed graph with vertices 4, 5, 10
+```
+
+One can also create labelled graph backed by a simple graph from `LightGraphs`.
+
+```julia
+using LabelledGraphs
+using LightGraphs
+
+g = path_graph(5)
+lg = LabelledGraph(["a", "b", "c", "d", "e"], g)
+```
+
+Once the graph is created, it can be used mostly like other graphs rom `LightGraph`.
+All method operate on labels given during graph's construction, for instance:
+
+```julia
+using LabelledGraphs
+using LightGraphs
+
+g = path_digraph(5)
+lg = LabelledGraph(["a", "b", "c", "d", "e"], g)
+
+println(vertices(lg))   # prints ["a", "b", "c", "d", "e"]
+println(edges(lg))      # prints edges "a" -> "b", "b" -> "c" etc.
+add_edge!(lg, "e", "b")
+println(inneighbors(lg, "b")) # prints ["a", "e"]
+```
+
+Additionally, one can add new vertices to the `LabelledGraph`, either by using `add_vertex!` or `add_vertices!`.
+
+```julia
+
+add_vertex!(lg, "f")
+add_vertices!(lg, ["u", "v", "w"])
+```

--- a/src/LabelledGraphs.jl
+++ b/src/LabelledGraphs.jl
@@ -1,5 +1,109 @@
-module LightGraphs
+module LabelledGraphs
 
+    using LightGraphs
+    export LabelledGraph, LabelledDiGraph, LabelledEdge
+
+    abstract type AbstractLabelledGraph{T} <: AbstractGraph{T} end
+
+
+    struct LabelledGraph{S <: AbstractGraph{U} where U <: Integer, T} <: AbstractLabelledGraph{T}
+        labels::Vector{T}
+        inner_graph::S
+        reverse_label_map::Dict{T, Integer}
+
+        function LabelledGraph(labels::Vector{T}, graph::S) where T where S <: AbstractGraph{U} where U <: Integer
+            if length(labels) != nv(graph)
+                throw(ArgumentError("Labels and inner graph's vertices have to be equinumerous."))
+            elseif !allunique(labels)
+                throw(ArgumentError("Labels have to be unique."))
+            else
+                new{S, T}(labels, graph, Dict(label => i for (label, i) ∈ zip(labels, vertices(graph))))
+            end
+        end
+    end
+
+
+    struct LabelledEdge{T} <: AbstractEdge{T}
+        src::T
+        dst::T
+    end
+
+    LightGraphs.src(e::LabelledEdge{T}) where T = e.src
+    LightGraphs.dst(e::LabelledEdge{T}) where T = e.dst
+
+
+    # --- External constructors ---
+    LabelledGraph{S}(labels::Vector{T}) where T where S <: AbstractGraph =
+        LabelledGraph(labels, S(length(labels)))
+
+
+    # --- Querying vertices ---
+    LightGraphs.nv(g::LabelledGraph) = length(g.labels)
+
+    LightGraphs.vertices(g::LabelledGraph) = g.labels
+
+    LightGraphs.has_vertex(g::LabelledGraph, v) = v in g.labels
+
+
+    # --- Querying edges ---
+    LightGraphs.ne(g::LabelledGraph) = ne(g.inner_graph)
+
+    LightGraphs.edges(g::LabelledGraph) =
+        map(e -> LabelledEdge(g.labels[src(e)], g.labels[dst(e)]), edges(g.inner_graph))
+
+    LightGraphs.has_edge(g::LabelledGraph, s, d) =
+        has_vertex(g, s) &&
+        has_vertex(g, d) &&
+        has_edge(g.inner_graph, g.reverse_label_map[s], g.reverse_label_map[d])
+
+    LightGraphs.has_edge(g::LabelledGraph, e::LightGraphs.AbstractEdge) =
+        has_edge(g, src(e), dst(e))
+
+
+    # --- Querying neighborhoods ---
+    LightGraphs.outneighbors(g::LabelledGraph{S, T}, v::T) where S where T =
+        [g.labels[u] for u ∈ outneighbors(g.inner_graph, g.reverse_label_map[v])]
+
+    LightGraphs.inneighbors(g::LabelledGraph{S, T}, v::T) where S where T =
+        [g.labels[u] for u ∈ inneighbors(g.inner_graph, g.reverse_label_map[v])]
+
+    LightGraphs.all_neighbors(g::LabelledGraph{S, T}, v::T) where S where T =
+        collect(union(Set(inneighbors(g, v)), Set(outneighbors(g, v))))
+
+
+    # --- Querying other graph properties ---
+    LightGraphs.is_directed(::Type{LabelledGraph{S, T}}) where S where T = is_directed(S)
+
+
+    # --- Mutations ---
+    # Warning: this might need further adjustments if we incorporate support for static graphs,
+    # as they are immutable.
+    LightGraphs.add_edge!(lg::LabelledGraph{S, T}, s::T, d::T) where S where T =
+        add_edge!(lg.inner_graph, lg.reverse_label_map[s], lg.reverse_label_map[d])
+
+    LightGraphs.add_edge!(lg::LabelledGraph{S, T}, e::AbstractEdge{T}) where S where T =
+        add_edge!(lg, src(e), dst(e))
+
+    function LightGraphs.add_vertex!(lg::LabelledGraph{S, T}, v::T) where S where T
+        if v ∈ lg.labels
+            throw(ArgumentError("Duplicate labels are not allowed"))
+        end
+        add_vertex!(lg.inner_graph)
+        push!(lg.labels, v)
+        push!(lg.reverse_label_map, v => nv(lg.inner_graph))
+    end
+
+    function LightGraphs.add_vertices!(lg::LabelledGraph{S, T}, vertices::Vector{T}) where S where T
+        if any(v ∈ lg.labels for v ∈ vertices)
+            throw(ArgumentError("Duplicate labels are not allowed"))
+        end
+        foreach(label -> add_vertex!(lg, label), vertices)
+    end
+
+
+    # --- Default-type aliases ---
+    LabelledGraph(labels::Vector{T}) where T = LabelledGraph{SimpleGraph}(labels)
+    LabelledDiGraph(labels::Vector{T}) where T = LabelledGraph{SimpleDiGraph}(labels)
 
 
 end

--- a/src/LabelledGraphs.jl
+++ b/src/LabelledGraphs.jl
@@ -1,0 +1,5 @@
+module LightGraphs
+
+
+
+end

--- a/src/LabelledGraphs.jl
+++ b/src/LabelledGraphs.jl
@@ -97,7 +97,7 @@ module LabelledGraphs
         if any(v ∈ lg.labels for v ∈ vertices)
             throw(ArgumentError("Duplicate labels are not allowed"))
         end
-        foreach(label -> add_vertex!(lg, label), vertices)
+        add_vertex!.(Ref(lg), vertices)
     end
 
 

--- a/src/LabelledGraphs.jl
+++ b/src/LabelledGraphs.jl
@@ -3,10 +3,8 @@ module LabelledGraphs
     using LightGraphs
     export LabelledGraph, LabelledDiGraph, LabelledEdge
 
-    abstract type AbstractLabelledGraph{T} <: AbstractGraph{T} end
 
-
-    struct LabelledGraph{S <: AbstractGraph{U} where U <: Integer, T} <: AbstractLabelledGraph{T}
+    struct LabelledGraph{S <: AbstractGraph{U} where U <: Integer, T} <: AbstractGraph{T}
         labels::Vector{T}
         inner_graph::S
         reverse_label_map::Dict{T, Integer}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,219 @@
+using LightGraphs
+using Test
+
+using LabelledGraphs
+
+
+for graph_type ∈ [SimpleGraph, SimpleDiGraph]
+@testset "Initializing LabelledGraph with another graph of type $graph_type" begin
+
+    @testset "fails if number of labels is different than source graph's number of vertices" begin
+        g = graph_type(5)
+        labels = [1, 4, 5, 3]
+        @test_throws ArgumentError LabelledGraph(labels, g)
+    end
+
+    @testset "fails if labels are not unique" begin
+        g = path_digraph(4)
+        labels = [1, 5, 10, 5]
+        @test_throws ArgumentError LabelledGraph(labels, g)
+    end
+
+
+    @testset "gives a graph isomorphic to the source graph" begin
+        g = graph_type(4)
+        for (i, j) ∈ [(1, 2), (3, 2), (2, 4)] add_edge!(g, i, j) end
+        labels = [20, 4, 5, 6]
+
+        lg = LabelledGraph(labels, g)
+
+        @testset "number of vertices in both graphs is the same" begin
+            @test nv(lg) == nv(g)
+        end
+
+        @testset "sequence of vertices of LabelledGraph is equal to the labels used" begin
+            @test collect(vertices(lg)) == labels
+        end
+
+        @testset "presence and absence of vertices is correctly reported" begin
+            for v ∈ (20, 4, 5, 6)
+                @test has_vertex(lg, v)
+            end
+
+            @test !has_vertex(lg, 1)
+        end
+
+        @testset "number of edges in both graph sis the same" begin
+            @test ne(lg) == ne(g) == length(edges(lg))
+        end
+
+        # For non-directed LightGraphs, edges are reported lex-ordered, regardless of
+        # the ordering of the original edge (i.e. edge (2, 1) is always reported as (1, 2)).
+        # Since this ordering propagates to our LabelledGraphs, we need to define set of
+        # expected edges accordingly.
+        expected_edges = is_directed(g) ?
+            [(i, j) for (i, j) ∈ [(20, 4), (5, 4), (4, 6)]] :
+            [(i, j) for (i, j) ∈ [(20, 4), (4, 5), (4, 6)]]
+        @testset "set of edges of LabelledGraph comprises source graph's edges with vertices mapped to labels" begin
+            @test Set([(src(e), dst(e)) for e ∈ edges(lg)]) == Set(expected_edges)
+        end
+
+        @testset "presence and absence of edges is correctly reported" begin
+            for (u, v) ∈ expected_edges
+                @test has_edge(lg, LabelledEdge(u, v))
+                @test has_edge(lg, u, v)
+            end
+
+            @test !has_edge(lg, 1, 2)
+            @test !has_edge(lg, LabelledEdge(1, 2))
+        end
+
+        @testset "LabelledGraph is directed iff source graph is also directed" begin
+            @test is_directed(lg) == is_directed(g)
+        end
+    end
+end
+end
+
+
+for graph_type ∈ [SimpleGraph, SimpleDiGraph]
+@testset "Initializing LabelledGraph{$graph_type} with only labels" begin
+    lg = LabelledGraph{graph_type}([1, 7, 3, 5])
+
+    @testset "gives graph with vertices corresponding to the labels" begin
+        @test vertices(lg) == [1, 7, 3, 5]
+    end
+
+    @testset "and an empty set of edges" begin
+        @test ne(lg) == length(edges(lg)) == 0
+    end
+end
+end
+
+
+@testset "Adding edge (s, d) to undirected LabelledGraph" begin
+    lg = LabelledGraph{SimpleGraph}([4, 5, 0])
+
+    add_edge!(lg, 4, 5)
+    add_edge!(lg, LabelledEdge(4, 0))
+
+    @testset "makes both (s, d) and (d, s) present in the graph begin" begin
+        @test has_edge(lg, 4, 5) && has_edge(lg, 5, 4)
+        @test has_edge(lg, 4, 0) && has_edge(lg, 0, 4)
+    end
+
+    @testset "does not add any other edge" begin
+        @test ne(lg) == length(edges(lg)) == 2
+    end
+
+    @testset "makes s and d both ingoing and outgoing neighbors" begin
+        @test 4 ∈ neighbors(lg, 5) && 4 ∈ outneighbors(lg, 5) && 4 ∈ inneighbors(lg, 5)
+        @test 5 ∈ neighbors(lg, 4) && 5 ∈ outneighbors(lg, 4) && 5 ∈ inneighbors(lg, 4)
+
+        @test 4 ∈ neighbors(lg, 0) && 4 ∈ outneighbors(lg, 0) && 4 ∈ inneighbors(lg, 0)
+        @test 0 ∈ neighbors(lg, 4) && 0 ∈ outneighbors(lg, 4) && 0 ∈ inneighbors(lg, 4)
+    end
+end
+
+
+@testset "Adding (s, d) edge to directed LabelledGraph" begin
+    lg = LabelledGraph{SimpleDiGraph}(["a", "b", "c", "d"])
+
+    add_edge!(lg, "a", "c")
+    add_edge!(lg, "d", "a")
+
+    @testset "does not add (d, s) edge" begin
+        @test has_edge(lg, "a", "c") && !has_edge(lg, "c", "a")
+        @test has_edge(lg, "d", "a") && !has_edge(lg, "a", "d")
+    end
+
+    @testset "does not add any other edge" begin
+        @test ne(lg) == length(edges(lg)) == 2
+    end
+
+    @testset "makes s and d neighbors (as reported by all_neighbors)" begin
+        @test "a" ∈ all_neighbors(lg, "c") && "c" ∈ all_neighbors(lg, "a")
+        @test "d" ∈ all_neighbors(lg, "a") && "a" ∈ all_neighbors(lg, "d")
+    end
+
+    @testset "makes s an ingoing neighbor of d and d outgoing neighbor of s" begin
+        @test "a" ∈ inneighbors(lg, "c") && "c" ∈ outneighbors(lg, "a")
+        @test "d" ∈ inneighbors(lg, "a") && "a" ∈ outneighbors(lg, "d")
+    end
+end
+
+
+for source_graph ∈ (path_digraph(5), path_graph(5))
+@testset "Adding vertex to LabelledGraph{$source_graph}" begin
+
+    lg = LabelledGraph(["a", "b", "c", "d", "e"], source_graph)
+
+    @testset "is not possible if the label is duplicated" begin
+        @test_throws ArgumentError add_vertex!(lg, "a")
+    end
+
+    add_vertex!(lg, "f")
+
+    @testset "makes new vertex present in vertices list" begin
+        @test "f" ∈ vertices(lg)
+    end
+
+    @testset "increases number of vertices by one" begin
+        @test nv(lg) == length(vertices(lg)) == 6
+    end
+
+    @testset "makes it possible to connect new vertex to previously existing one" begin
+        add_edge!(lg, "f", "b")
+        @test has_edge(lg, "f", "b")
+    end
+end
+end
+
+
+for source_graph ∈ (path_digraph(5), path_graph(5))
+@testset "Adding multiple vertices to LabelledGraph{$(typeof(source_graph))}" begin
+
+    lg = LabelledGraph(["a", "b", "c", "d", "e"], source_graph)
+
+    @testset "is not possible if any labels are duplicated, in which case no verts are added" begin
+        @test_throws ArgumentError add_vertices!(lg, ["f", "g", "h", "a"])
+        @test nv(lg) == 5
+    end
+
+    new_labels = ["u", "v", "w"]
+    add_vertices!(lg, new_labels)
+
+    @testset "makes new vertices present in vertices list" begin
+        @test all(label ∈ vertices(lg) for label ∈ new_labels)
+    end
+
+    @testset "increases number of vertices by the number of added vertices" begin
+        @test nv(lg) == length(vertices(lg)) == 8
+    end
+
+    @testset "makes it possible to connect any two of new vertices" begin
+        add_edge!(lg, "u", "w")
+        add_edge!(lg, "w", "v")
+        @test has_edge(lg, "u", "w")
+        @test has_edge(lg, "w", "v")
+    end
+
+    @testset "makes it possible to connet new vertex and previously existing one" begin
+        add_edge!(lg, "w", "a")
+        add_edge!(lg, "b", "u")
+        @test has_edge(lg, "w", "a")
+        @test has_edge(lg, "b", "u")
+    end
+end
+end
+
+
+@testset "LabelledGraph can be constructed using default-type aliases" begin
+    lg = LabelledGraph(["a", "b", "c"])
+    @test !is_directed(lg)
+    @test nv(lg) == 3
+
+    lg = LabelledDiGraph(["a", "b", "c"])
+    @test is_directed(lg)
+    @test nv(lg) == 3
+end


### PR DESCRIPTION
This adds an initial implementation of `LabelledGraph`. Few key points:

- Labelled graphs are graphs whose vertices can be labelled with arbitrary unique objects (integers, strings, whatever)
- Each labelled graph is backed by another graph from `LightGraphs` package, and most `LabelledGraph` methods are proxies to respective methods from `LightGraphs` that translate vertex indices to labels (or the opposite way)
- Implementation is quite short and therefore I decided to put it in a single file. @lpawela let me know if this is considered a bad practice in Julia. The same with tests (everything is in runtests.jl)
- Purposefully this does not implement meta-graph methods for `LabelledGraph` backed by `MetaGraph`. This is to not add `MetaGraphs` dependency, and I imagine creating a separate package `LabelledMetaGraphs.jl` that implements meta-graph methods for `LabelledGraphs`.